### PR TITLE
Set CI to run on default branch: main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,9 @@
 name: CI
-# Run on master, any tag or any pull request
+# Run on main, any tag or any pull request
 on:
   push:
     branches:
-      - master
+      - main
       - staging
       - trying
     tags: '*'


### PR DESCRIPTION
The default branch of this repo is set to `main` so this reflects that.