### PR TITLE
Docs Documenter@0.26

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ AWSBatch = "dcae83d4-2881-5875-9d49-e5534165e9c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.27"
+Documenter = "0.26"


### PR DESCRIPTION
```
ERROR: Unsatisfiable requirements detected for package Documenter [e30172f5]:
 Documenter [e30172f5] log:
 ├─possible versions are: [0.19.0-0.19.7, 0.20.0, 0.21.0-0.21.5, 0.22.0-0.22.6, 0.23.0-0.23.4, 0.24.0-0.24.11, 0.25.0-0.25.5, 0.26.0-0.26.3] or uninstalled
 └─restricted to versions 0.27 by an explicit requirement — no versions left
```

https://github.com/JuliaCloud/AWSBatch.jl/runs/2069059414?check_suite_focus=true#step:4:18