### PR TITLE
Fix array jobs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "AWSBatch"
 uuid = "dcae83d4-2881-5875-9d49-e5534165e9c0"
 license = "MIT"
 authors = ["Invenia Technical Computing"]
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
@@ -15,6 +15,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 AWS = "1"
+AWSTools = "2"
 AutoHashEquals = "0.2.0"
 Memento = "0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 1"
 Mocking = "0.7"
@@ -22,8 +23,9 @@ OrderedCollections = "1.4"
 julia = "1"
 
 [extras]
+AWSTools = "83bcdc74-1232-581c-948a-f29122bf8259"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["HTTP", "Test"]
+test = ["AWSTools", "HTTP", "Test"]

--- a/src/batch_job.jl
+++ b/src/batch_job.jl
@@ -46,7 +46,7 @@ function submit(
     if num_jobs > 1
         # https://docs.aws.amazon.com/batch/latest/userguide/array_jobs.html
         @assert 2 <= num_jobs <= 10_000
-        push!(input, "arrayProperties" => ["size" => num_jobs])
+        push!(input, "arrayProperties" => Dict("size" => num_jobs))
     end
 
     debug(logger, "Input: $input")

--- a/test/resources/batch.yml
+++ b/test/resources/batch.yml
@@ -217,3 +217,5 @@ Resources:
 Outputs:
   JobQueueArn:
     Value: !Ref JobQueue
+  JobRoleArn:
+    Value: !GetAtt JobRole.Arn

--- a/test/run_batch.jl
+++ b/test/run_batch.jl
@@ -53,6 +53,9 @@ end
         apply(patches) do
             job = run_batch(; name="example", definition="sleep60", queue="HighPriority")
             @test job.id == "24fa2d7a-64c4-49d2-8b47-f8da4fbde8e9"
+
+            job = run_batch(; name="example", definition="sleep60", queue="HighPriority", num_jobs=4)
+            @test job.id == "24fa2d7a-64c4-49d2-8b47-f8da4fbde8e9"
         end
     end
 

--- a/test/run_batch.jl
+++ b/test/run_batch.jl
@@ -54,7 +54,9 @@ end
             job = run_batch(; name="example", definition="sleep60", queue="HighPriority")
             @test job.id == "24fa2d7a-64c4-49d2-8b47-f8da4fbde8e9"
 
-            job = run_batch(; name="example", definition="sleep60", queue="HighPriority", num_jobs=4)
+            job = run_batch(;
+                name="example", definition="sleep60", queue="HighPriority", num_jobs=4
+            )
             @test job.id == "24fa2d7a-64c4-49d2-8b47-f8da4fbde8e9"
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using AWS
+using AWSTools.CloudFormation: stack_output
 using AWSBatch
 using Dates
 using HTTP: HTTP
@@ -10,10 +11,6 @@ using Test
 using AWS.AWSExceptions: AWSException
 
 Mocking.activate()
-
-# need to define these to make sure we don't inadvertently try to talk to AWS
-ENV["AWS_ACCESS_KEY_ID"] = ""
-ENV["AWS_SECRET_ACCESS_KEY"] = ""
 
 # Controls the running of various tests: "local", "batch"
 const TESTS = strip.(split(get(ENV, "TESTS", "local"), r"\s*,\s*"))
@@ -76,12 +73,15 @@ include("mock.jl")
 
 @testset "AWSBatch.jl" begin
     if "local" in TESTS
-        include("compute_environment.jl")
-        include("job_queue.jl")
-        include("log_event.jl")
-        include("job_state.jl")
-        include("batch_job.jl")
-        include("run_batch.jl")
+        # need to define these to make sure we don't inadvertently try to talk to AWS
+        withenv("AWS_ACCESS_KEY_ID" => "", "AWS_SECRET_ACCESS_KEY" => "") do
+            include("compute_environment.jl")
+            include("job_queue.jl")
+            include("log_event.jl")
+            include("job_state.jl")
+            include("batch_job.jl")
+            include("run_batch.jl")
+        end
     else
         warn(logger, "Skipping \"local\" tests. Set `ENV[\"TESTS\"] = \"local\"` to run.")
     end


### PR DESCRIPTION
Submitting an array job yielded 
```
HTTP.ExceptionRequest.StatusError(400, "POST", "/v1/submitjob", HTTP.Messages.Response:
"""
HTTP/1.1 400 Bad Request
Date: Fri, 17 Sep 2021 22:09:44 GMT
Content-Type: application/json
Content-Length: 78
Connection: keep-alive
x-amzn-RequestId: 511cf789-aee3-4162-be47-96d84864ac02
Access-Control-Allow-Origin: *
x-amz-apigw-id: F0_GTHOeIAMFq7w=
Access-Control-Expose-Headers: X-amzn-errortype,X-amzn-requestid,X-amzn-errormessage,X-amzn-trace-id,X-amz-apigw-id,date
X-Amzn-Trace-Id: Root=1-61451228-5ef067776f7562351f5edde5

{"message":"An error occurred during JSON parsing","__type":"ClientException"}""")
```
because an array was used in the parameter block instead of an object. 
This fixes the param structure and fixes the test logic to allow users to manually run the online tests.