### PR TITLE
Terminate Jobs w/ Prefix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "AWSBatch"
 uuid = "dcae83d4-2881-5875-9d49-e5534165e9c0"
 license = "MIT"
 authors = ["Invenia Technical Computing"]
-version = "2.0.1"
+version = "2.1.0"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,0 +1,59 @@
+_incomplete_job(job) = !(job["status"] in ["SUCCEEDED", "FAILED"])
+_suffix_asterisk(prefix) = endswith(prefix, "*") ? prefix : string(prefix, "*")
+
+function _get_job_ids(job_queue, prefix)
+    # Check if the prefix provided ends w/ '*", if not append it
+    prefix = _suffix_asterisk(prefix)
+
+    resp = @mock Batch.list_jobs(
+        Dict(
+            "jobQueue" => job_queue,
+            "filters" => [Dict("name" => "JOB_NAME", "values" => [prefix])],
+        ),
+    )
+    jobs = resp["jobSummaryList"]
+
+    while haskey(resp, "nextToken")
+        resp = @mock Batch.list_jobs(
+            Dict("jobQueue" => job_queue, "nextToken" => resp["nextToken"])
+        )
+        append!(jobs, resp["jobSummaryList"])
+    end
+
+    filter!(j -> _incomplete_job(j), jobs)
+
+    return [j["jobId"] for j in jobs]
+end
+
+"""
+    terminate_jobs()
+
+Terminate all Batch jobs with a given prefix.
+
+# Arguments
+- `job_queue::JobQueue`: JobQueue where the jobs reside
+- `prefix::AbstractString`: Prefix for the jobs
+
+# Keywords
+- `reason::AbstractString=""`: Reason to terminate the jobs
+
+# Return
+- `Array{String}`: Terminated Job Ids
+"""
+function terminate_jobs(
+    job_queue::AbstractString, prefix::AbstractString; reason::AbstractString=""
+)
+    job_ids = _get_job_ids(job_queue, prefix)
+
+    for job_id in job_ids
+        @mock Batch.terminate_job(job_id, reason)
+    end
+
+    return job_ids
+end
+
+function terminate_jobs(
+    job_queue::JobQueue, prefix::AbstractString; reason::AbstractString=""
+)
+    return terminate_jobs(job_queue.arn, prefix; reason=reason)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using AWS
+using AWS.AWSExceptions: AWSException
 using AWSTools.CloudFormation: stack_output
 using AWSBatch
 using Dates
@@ -7,8 +8,6 @@ using Memento
 using Memento.TestUtils: @test_log, @test_nolog
 using Mocking
 using Test
-
-using AWS.AWSExceptions: AWSException
 
 Mocking.activate()
 
@@ -81,6 +80,7 @@ include("mock.jl")
             include("job_state.jl")
             include("batch_job.jl")
             include("run_batch.jl")
+            include("utilities.jl")
         end
     else
         warn(logger, "Skipping \"local\" tests. Set `ENV[\"TESTS\"] = \"local\"` to run.")

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,0 +1,43 @@
+list_jobs_patch = @patch function AWSBatch.Batch.list_jobs(params)
+    response = Dict{String,Any}(
+        "jobSummaryList" => [
+            Dict("jobId" => "1", "status" => "SUCCEEDED"),
+            Dict("jobId" => "2", "status" => "FAILED"),
+            Dict("jobId" => "3", "status" => "RUNNABLE"),
+        ],
+    )
+
+    if !haskey(params, "nextToken")
+        response["nextToken"] = "nextToken"
+    end
+
+    return response
+end
+
+terminate_job_patch = @patch AWSBatch.Batch.terminate_job(a...) = Dict()
+
+@testset "_incomplete_job" begin
+    @test_throws KeyError AWSBatch._incomplete_job(Dict())
+    @test !AWSBatch._incomplete_job(Dict("status" => "SUCCEEDED"))
+    @test !AWSBatch._incomplete_job(Dict("status" => "FAILED"))
+    @test AWSBatch._incomplete_job(Dict("status" => "FOOBAR"))
+end
+
+@testset "_suffix_asterisk" begin
+    @test AWSBatch._suffix_asterisk("foobar") == "foobar*"
+    @test AWSBatch._suffix_asterisk("foobar*") == "foobar*"
+end
+
+@testset "_get_job_ids" begin
+    apply(list_jobs_patch) do
+        response = AWSBatch._get_job_ids("foo", "bar")
+        @test response == ["3", "3"]
+    end
+end
+
+@testset "terminate_jobs" begin
+    apply([list_jobs_patch, terminate_job_patch]) do
+        response = terminate_jobs("foo", "bar")
+        @test response == ["3", "3"]
+    end
+end


### PR DESCRIPTION
Add functionality to mass terminate jobs which start with a `prefix`.